### PR TITLE
Level2の実装(ユーザが入力したアーティストに対する類似アーティストを上位５件返信)

### DIFF
--- a/app/controllers/webhook_controller.rb
+++ b/app/controllers/webhook_controller.rb
@@ -74,14 +74,15 @@ class WebhookController < ApplicationController
   def make_reply_text(data)
     if data.nil? || (data["similarartists"]).nil?
       text = ERR_MESSAGE
-    else
-      similar_artists = data["similarartists"]["artist"]
-      text = similar_artists.each_with_object("").with_index {|(artist, text), i|
-        text << "#{i+1}: #{artist["name"]}\n"
-      }
-      if text.empty?
-        text = ERR_MESSAGE
-      end
+      return text.chomps
+    end
+
+    similar_artists = data["similarartists"]["artist"]
+    text = similar_artists.each_with_object("").with_index {|(artist, text), i|
+      text << "#{i+1}: #{artist["name"]}\n"
+    }
+    if text.empty?
+      text = ERR_MESSAGE
     end
     return text.chomp
   end

--- a/app/controllers/webhook_controller.rb
+++ b/app/controllers/webhook_controller.rb
@@ -59,6 +59,7 @@ class WebhookController < ApplicationController
     uri = URI.parse(URL_ROOT)
     uri.query = URI.encode_www_form({
       limit: LIMIT_NUM,
+      autocorrect: 1,
       method: "artist.getsimilar",
       artist: artist_name,
       api_key: API_KEY,
@@ -77,6 +78,9 @@ class WebhookController < ApplicationController
       text = similar_artists.each_with_object("").with_index {|(artist, text), i|
         text << "#{i+1}: #{artist["name"]}\n"
       }
+      if text.empty?
+        text = "アーティストが見つかりませんでした. "
+      end
     end
     return text.chomp
   end

--- a/app/controllers/webhook_controller.rb
+++ b/app/controllers/webhook_controller.rb
@@ -54,6 +54,7 @@ class WebhookController < ApplicationController
   API_KEY = ENV["API_KEY"]
   URL_ROOT = 'http://ws.audioscrobbler.com/2.0/'
   LIMIT_NUM = 5
+  ERR_MESSAGE = "アーティストが見つかりませんでした. "
 
   def get_json_from_lastapi(artist_name)
     uri = URI.parse(URL_ROOT)
@@ -72,14 +73,14 @@ class WebhookController < ApplicationController
 
   def make_reply_text(data)
     if data.nil? || (data["similarartists"]).nil?
-      text = "アーティストが見つかりませんでした. "
+      text = ERR_MESSAGE
     else
       similar_artists = data["similarartists"]["artist"]
       text = similar_artists.each_with_object("").with_index {|(artist, text), i|
         text << "#{i+1}: #{artist["name"]}\n"
       }
       if text.empty?
-        text = "アーティストが見つかりませんでした. "
+        text = ERR_MESSAGE
       end
     end
     return text.chomp

--- a/app/controllers/webhook_controller.rb
+++ b/app/controllers/webhook_controller.rb
@@ -30,7 +30,7 @@ class WebhookController < ApplicationController
           # レベル2の実装（特定メッセージに対して、Last.fmのAPIをコールして、類似度上位５件のアーティスト名を応答する。https://www.last.fm/api/）
           artist_name = event.message['text'].strip
 
-          data = get_json_from_lastapi(artist_name)
+          data = get_similar_artists(artist_name)
 
           text = make_reply_text(data)
 
@@ -56,7 +56,7 @@ class WebhookController < ApplicationController
   LIMIT_NUM = 5
   ERR_MESSAGE = "アーティストが見つかりませんでした. "
 
-  def get_json_from_lastapi(artist_name)
+  def get_similar_artists(artist_name)
     uri = URI.parse(URL_ROOT)
     uri.query = URI.encode_www_form({
       limit: LIMIT_NUM,


### PR DESCRIPTION
## 実装の背景・目的

<img width="752" alt="スクリーンショット 2020-03-17 17 56 44" src="https://user-images.githubusercontent.com/47667592/76839431-d1983980-6878-11ea-8ca0-09160fb3de4a.png">

上記機能を満たすコードを実装しました。

## やったこと

- Last.fmのAPIに対し、GETを送る（ユーザからのメーセージ文をパラメータとして持たせる）
- レスポンスをJSONに変換
- each文でJSONからアーティスト名を抜き出して、一つの文字列としてまとめる
- できた文字列をユーザに返信する

## キャプチャ
<img width="398" alt="スクリーンショット 2020-03-17 17 55 41" src="https://user-images.githubusercontent.com/47667592/76839254-89791700-6878-11ea-96c6-a723f0eb658e.png">

