### PR TITLE
Level 3

### DIFF
--- a/app/controllers/webhook_controller.rb
+++ b/app/controllers/webhook_controller.rb
@@ -97,7 +97,7 @@ class WebhookController < ApplicationController
     top_tracks_ranking = top_tracks.each_with_object("").with_index {|(track, text), i|
       row = "#{i+1}: #{track["name"]}\n"
 
-      # 曲名が一行あたり20文字以下になるよう調整
+      # 曲名が一行あたり20文字以下になるよう調整（LINEのAPIの仕様上、textが60文字までしか入力できないから）
       if row.size >= MAX_NUM_PER_ROW
         row = "#{row.slice(0, MAX_NUM_PER_ROW-4)}…\n"
       end

--- a/app/controllers/webhook_controller.rb
+++ b/app/controllers/webhook_controller.rb
@@ -71,7 +71,7 @@ class WebhookController < ApplicationController
     })
 
     res = Net::HTTP.get_response(uri)
-    return JSON.parse(res.body.to_s)
+    JSON.parse(res.body.to_s)
   end
 
   def get_artist_toptracks(artist_name)
@@ -86,7 +86,7 @@ class WebhookController < ApplicationController
     })
 
     res = Net::HTTP.get_response(uri)
-    return JSON.parse(res.body.to_s)
+    JSON.parse(res.body.to_s)
   end
 
   def make_carousel(similar_artists_data)
@@ -142,7 +142,7 @@ class WebhookController < ApplicationController
       }
     }
 
-    return message
+    message
   end
 
 end

--- a/app/controllers/webhook_controller.rb
+++ b/app/controllers/webhook_controller.rb
@@ -57,6 +57,8 @@ class WebhookController < ApplicationController
   ARTIST_IMG_URL = "https://lastfm.freetls.fastly.net/i/u/174s/2a96cbd8b46e442fc41c2b86b821562f.png"
   IMG_BACK_GROUND_COLOR = "#FFFFFF"
   BUTTON_MESSAGE = "このアーティストでさらに検索"
+  MAX_NUM_PER_ROW = 21
+
 
   def get_similar_artists(artist_name)
     uri = URI.parse(URL_ROOT)
@@ -109,9 +111,9 @@ class WebhookController < ApplicationController
       top_tracks_ranking = top_tracks.each_with_object("").with_index {|(track, text), i|
         row = "#{i+1}: #{track["name"]}\n"
 
-        # 曲名が一行あたりが２０文字以下になるよう調整
-        if row.size >= 21
-          row = "#{row.slice(0, 17)}…\n"
+        # 曲名が一行あたり20文字以下になるよう調整
+        if row.size >= MAX_NUM_PER_ROW
+          row = "#{row.slice(0, MAX_NUM_PER_ROW-4)}…\n"
         end
         text << row
       }

--- a/app/controllers/webhook_controller.rb
+++ b/app/controllers/webhook_controller.rb
@@ -35,7 +35,7 @@ class WebhookController < ApplicationController
           message = make_carousel(similar_artists_data)
           # 完成したカルーセルテンプレートをユーザに送り返す
           response = client.reply_message(event['replyToken'], message)
-          puts response.body
+          logger.debug(response.body)
 
         when Line::Bot::Event::MessageType::Image, Line::Bot::Event::MessageType::Video
           response = client.get_message_content(event.message['id'])

--- a/app/controllers/webhook_controller.rb
+++ b/app/controllers/webhook_controller.rb
@@ -53,12 +53,11 @@ class WebhookController < ApplicationController
   URL_ROOT = 'http://ws.audioscrobbler.com/2.0/'
   ARTIST_LIMIT_NUM = 10
   TRACK_LIMIT_NUM = 3
-  ERR_MESSAGE = "アーティストが見つかりませんでした. "
+  ERR_MESSAGE = "ごめん、アーティストが見つかんなかった💦"
   ARTIST_IMG_URL = "https://lastfm.freetls.fastly.net/i/u/174s/2a96cbd8b46e442fc41c2b86b821562f.png"
   IMG_BACK_GROUND_COLOR = "#FFFFFF"
-  BUTTON_MESSAGE = "このアーティストでさらに検索"
+  BUTTON_MESSAGE = "ここからさらにディグる"
   MAX_NUM_PER_ROW = 21
-
 
   def get_similar_artists(artist_name)
     uri = URI.parse(URL_ROOT)

--- a/app/controllers/webhook_controller.rb
+++ b/app/controllers/webhook_controller.rb
@@ -89,6 +89,23 @@ class WebhookController < ApplicationController
     JSON.parse(res.body.to_s)
   end
 
+  def make_toptracks_ranking(artist)
+    artist_toptracks_data = get_artist_toptracks(artist["name"])
+
+    top_tracks = artist_toptracks_data["toptracks"]["track"]
+
+    top_tracks_ranking = top_tracks.each_with_object("").with_index {|(track, text), i|
+      row = "#{i+1}: #{track["name"]}\n"
+
+      # 曲名が一行あたり20文字以下になるよう調整
+      if row.size >= MAX_NUM_PER_ROW
+        row = "#{row.slice(0, MAX_NUM_PER_ROW-4)}…\n"
+      end
+      text << row
+    }
+    top_tracks_ranking
+  end
+
   def make_carousel(similar_artists_data)
     # アーティストが検索に引っかからなかった場合、または関連するアーティストが存在しない場合
     if similar_artists_data.dig("similarartists", "artist", 0).nil?
@@ -102,19 +119,7 @@ class WebhookController < ApplicationController
     similar_artists = similar_artists_data["similarartists"]["artist"]
 
     columns = similar_artists.each_with_object([]) {|artist, columns|
-      artist_toptracks_data = get_artist_toptracks(artist["name"])
-
-      top_tracks = artist_toptracks_data["toptracks"]["track"]
-
-      top_tracks_ranking = top_tracks.each_with_object("").with_index {|(track, text), i|
-        row = "#{i+1}: #{track["name"]}\n"
-
-        # 曲名が一行あたり20文字以下になるよう調整
-        if row.size >= MAX_NUM_PER_ROW
-          row = "#{row.slice(0, MAX_NUM_PER_ROW-4)}…\n"
-        end
-        text << row
-      }
+      top_tracks_ranking = make_toptracks_ranking(artist)
 
       columns.push({
         thumbnailImageUrl: ARTIST_IMG_URL,

--- a/app/controllers/webhook_controller.rb
+++ b/app/controllers/webhook_controller.rb
@@ -27,13 +27,13 @@ class WebhookController < ApplicationController
         case event.type
         when Line::Bot::Event::MessageType::Text
 
-          # レベル3の実装
+          # ユーザから送られてきたテキストを変数化
           artist_name = event.message['text'].strip
-
+          # Last.fmのAPIを叩いて類似アーティストの情報を取得
           similar_artists_data = get_similar_artists(artist_name)
-
+          # 類似アーティストをそれぞれカルーセルテンプレートに当てはめる
           message = make_carousel(similar_artists_data)
-
+          # 完成したカルーセルテンプレートをユーザに送り返す
           response = client.reply_message(event['replyToken'], message)
           puts response.body
 

--- a/app/controllers/webhook_controller.rb
+++ b/app/controllers/webhook_controller.rb
@@ -91,9 +91,8 @@ class WebhookController < ApplicationController
   end
 
   def make_carousel(similar_artists_data)
-
     # アーティストが検索に引っかからなかった場合、または関連するアーティストが存在しない場合
-    if similar_artists_data.nil? || (similar_artists_data["similarartists"]).nil? || (similar_artists_data["similarartists"]["artist"]).empty?
+    if similar_artists_data.dig("similarartists", "artist", 0).nil?
       message = {
         type: 'text',
         text: ERR_MESSAGE


### PR DESCRIPTION
## 実装の背景・目的

level2では類似アーティストをテキストとして出力していたが、
level3ではカルーセルテンプレートを使い、よりリッチなUIで類似アーティストを表示することを目的としました。

## やったこと

-  類似アーティストのデータをLast.fmのAPIから取ってくる
- 「類似アーティストの名前」、「人気曲の上位３つ」、「さらに検索ボタン」をカルーセルテンプレートに乗せて表示
- 「人気曲の上位３つ」の文字列が６０文字以上にならないようにエラー処理

## キャプチャ

<img width="806" alt="スクリーンショット 2020-03-19 12 56 22" src="https://user-images.githubusercontent.com/47667592/77030128-0fb06d00-69e1-11ea-8506-cbcf117b1eb7.png">

## 補足

- アーティストの画像表示がうまくいかなかったので、残り時間でそこを解決したい
